### PR TITLE
CI/CD - Disable the truthy warning in yml file

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,7 @@
 name: Check Set-Up & Build
 
 # Controls when the action will run.
+# yamllint disable-line rule:truthy
 on:
   # Triggers the workflow on push or pull request events
   # but only for the calamari (default) branch.


### PR DESCRIPTION
closes #25 
* Disable ``` [truthy] truthy value should be one of [false, true] ``` warning in yml files