### PR TITLE
[Manta]Use type aliases to fix the issue about front-end loads the backend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub const PRIVATE_TRANSFER_PAYLOAD_SIZE: usize = 608;
 pub const RECLAIM_PAYLOAD_SIZE: usize = 512;
 
 /// Type aliases
-pub type PrivatePayload = [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
+pub type PrivateTransferPayload = [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
 pub type ReclaimPayload = [u8; RECLAIM_PAYLOAD_SIZE];
 
 /// The module configuration trait.
@@ -341,7 +341,7 @@ decl_module! {
 		/// Neither the values nor the identities is leaked during this process.
 		#[weight = T::WeightInfo::private_transfer()]
 		fn private_transfer(origin,
-			payload: PrivatePayload,
+			payload: PrivateTransferPayload,
 		) {
 			// this function does not know which asset_id is been transferred.
 			// so there will not be an initialization check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,8 @@ pub const PRIVATE_TRANSFER_PAYLOAD_SIZE: usize = 608;
 pub const RECLAIM_PAYLOAD_SIZE: usize = 512;
 
 /// Type aliases
-pub type PrivatePayload =  [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
-pub type ReclaimPayload =  [u8; RECLAIM_PAYLOAD_SIZE];
+pub type PrivatePayload = [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
+pub type ReclaimPayload = [u8; RECLAIM_PAYLOAD_SIZE];
 
 /// The module configuration trait.
 pub trait Config: frame_system::Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,10 @@ pub const MINT_PAYLOAD_SIZE: usize = 112;
 pub const PRIVATE_TRANSFER_PAYLOAD_SIZE: usize = 608;
 pub const RECLAIM_PAYLOAD_SIZE: usize = 512;
 
+/// Type aliases
+pub type PrivatePayload =  [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
+pub type ReclaimPayload =  [u8; RECLAIM_PAYLOAD_SIZE];
+
 /// The module configuration trait.
 pub trait Config: frame_system::Config {
 	/// The overarching event type.
@@ -337,7 +341,7 @@ decl_module! {
 		/// Neither the values nor the identities is leaked during this process.
 		#[weight = T::WeightInfo::private_transfer()]
 		fn private_transfer(origin,
-			payload: [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE],
+			payload: PrivatePayload,
 		) {
 			// this function does not know which asset_id is been transferred.
 			// so there will not be an initialization check
@@ -435,7 +439,7 @@ decl_module! {
 		/// __TODO__: shall we use a different receiver rather than `origin`?
 		#[weight = T::WeightInfo::reclaim()]
 		fn reclaim(origin,
-			payload: [u8; RECLAIM_PAYLOAD_SIZE],
+			payload: ReclaimPayload,
 		) {
 
 			let data = ReclaimData::deserialize(payload.as_ref());


### PR DESCRIPTION
Fix the error from front-end while load backend.
```
FATAL: Unable to initialize the API: [u8;PRIVATE_TRANSFER_PAYLOAD_SIZE]: Only support for [Type; <length>], where length <= 256
```