### PR TITLE
[Pallet-Manta-Pay] Must fail tests for the mint_private_asset and transfer_asset extrinsics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ decl_module! {
 		/// - 2 storage writes (codec `O(1)`).
 		/// - 1 event.
 		/// # </weight>
-		#[weight = T::WeightInfo::mint_private_asset()]
+		#[weight = T::WeightInfo::init_asset()]
 		fn init_asset(origin,
 			asset_id: u64,
 			total: u64

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,10 @@ pub const MINT_PAYLOAD_SIZE: usize = 112;
 pub const PRIVATE_TRANSFER_PAYLOAD_SIZE: usize = 608;
 pub const RECLAIM_PAYLOAD_SIZE: usize = 512;
 
+/// Type aliases
+pub type PrivatePayload = [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
+pub type ReclaimPayload = [u8; RECLAIM_PAYLOAD_SIZE];
+
 /// The module configuration trait.
 pub trait Config: frame_system::Config {
 	/// The overarching event type.
@@ -159,7 +163,7 @@ decl_module! {
 		/// - 2 storage writes (codec `O(1)`).
 		/// - 1 event.
 		/// # </weight>
-		#[weight = T::WeightInfo::init_asset()]
+		#[weight = T::WeightInfo::mint_private_asset()]
 		fn init_asset(origin,
 			asset_id: u64,
 			total: u64
@@ -337,7 +341,7 @@ decl_module! {
 		/// Neither the values nor the identities is leaked during this process.
 		#[weight = T::WeightInfo::private_transfer()]
 		fn private_transfer(origin,
-			payload: [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE],
+			payload: PrivatePayload,
 		) {
 			// this function does not know which asset_id is been transferred.
 			// so there will not be an initialization check
@@ -435,7 +439,7 @@ decl_module! {
 		/// __TODO__: shall we use a different receiver rather than `origin`?
 		#[weight = T::WeightInfo::reclaim()]
 		fn reclaim(origin,
-			payload: [u8; RECLAIM_PAYLOAD_SIZE],
+			payload: ReclaimPayload,
 		) {
 
 			let data = ReclaimData::deserialize(payload.as_ref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,8 +277,9 @@ decl_module! {
 			let origin_balance = <Balances<T>>::get(&origin_account, input.asset_id);
 			ensure!(origin_balance >= input.amount, Error::<T>::BalanceLow);
 
-			// get the parameter checksum from the ledger
-			// and make sure the parameters match
+			// HASH_PARAM and COMMIT_PARAM are too big to keep on chain,
+			// therefore we only store their checksums.
+			// Retreive them from the ledger and make sure they match to the locals
 			let hash_param_checksum_local = HASH_PARAM.get_checksum();
 			let commit_param_checksum_local = COMMIT_PARAM.get_checksum();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,6 @@ pub const MINT_PAYLOAD_SIZE: usize = 112;
 pub const PRIVATE_TRANSFER_PAYLOAD_SIZE: usize = 608;
 pub const RECLAIM_PAYLOAD_SIZE: usize = 512;
 
-/// Type aliases
-pub type PrivatePayload = [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
-pub type ReclaimPayload = [u8; RECLAIM_PAYLOAD_SIZE];
-
 /// The module configuration trait.
 pub trait Config: frame_system::Config {
 	/// The overarching event type.
@@ -163,7 +159,7 @@ decl_module! {
 		/// - 2 storage writes (codec `O(1)`).
 		/// - 1 event.
 		/// # </weight>
-		#[weight = T::WeightInfo::mint_private_asset()]
+		#[weight = T::WeightInfo::init_asset()]
 		fn init_asset(origin,
 			asset_id: u64,
 			total: u64
@@ -341,7 +337,7 @@ decl_module! {
 		/// Neither the values nor the identities is leaked during this process.
 		#[weight = T::WeightInfo::private_transfer()]
 		fn private_transfer(origin,
-			payload: PrivatePayload,
+			payload: [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE],
 		) {
 			// this function does not know which asset_id is been transferred.
 			// so there will not be an initialization check
@@ -439,7 +435,7 @@ decl_module! {
 		/// __TODO__: shall we use a different receiver rather than `origin`?
 		#[weight = T::WeightInfo::reclaim()]
 		fn reclaim(origin,
-			payload: ReclaimPayload,
+			payload: [u8; RECLAIM_PAYLOAD_SIZE],
 		) {
 
 			let data = ReclaimData::deserialize(payload.as_ref());

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -195,7 +195,12 @@ fn mint_with_invalid_commit_should_not_work() {
 	new_test_ext().execute_with(|| {
 		mint_tokens_setup_helper();
 
-		let commit_param = CommitmentParam::deserialize(Parameter{data:&[0u8; 81664]}.data);
+		let commit_param = CommitmentParam::deserialize(
+			Parameter {
+				data: &[0u8; 81664],
+			}
+			.data,
+		);
 		let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
 		let mut sk = [0u8; 32];
 		rng.fill_bytes(&mut sk);
@@ -208,7 +213,6 @@ fn mint_with_invalid_commit_should_not_work() {
 		);
 	});
 }
-
 
 #[test]
 fn test_transfer_should_work() {

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -180,6 +180,22 @@ fn mint_with_insufficient_origin_balance_should_not_work() {
 }
 
 #[test]
+fn mint_with_eisting_coin_should_not_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Assets::init_asset(Origin::signed(1), TEST_ASSET, 100));
+		assert_eq!(Assets::balance(1, TEST_ASSET), 100);
+		assert_eq!(PoolBalance::get(TEST_ASSET), 0);
+
+		let payload = generate_mint_payload_helper(50);
+		Assets::mint_private_asset(Origin::signed(1), payload);
+		assert_noop!(
+			Assets::mint_private_asset(Origin::signed(1), payload),
+			Error::<Test>::MantaCoinExist
+		);
+	});
+}
+
+#[test]
 fn test_transfer_should_work() {
 	new_test_ext().execute_with(|| transfer_test_helper(1));
 }

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -194,7 +194,7 @@ fn mint_with_existing_coin_should_not_work() {
 fn mint_with_invalid_commitment_should_not_work() {
 	new_test_ext().execute_with(|| {
 		mint_tokens_setup_helper();
-		
+
 		let commit_param = CommitmentParam::deserialize(
 			Parameter {
 				data: &[0u8; 81664],
@@ -222,7 +222,7 @@ fn mint_with_hash_param_mismatch_should_not_work() {
 		let payload = generate_mint_payload_helper(50);
 		assert_ok!(Assets::mint_private_asset(Origin::signed(1), payload));
 
-		HashParamChecksum::put([3u8;32]);
+		HashParamChecksum::put([3u8; 32]);
 
 		assert_noop!(
 			Assets::mint_private_asset(Origin::signed(1), payload),
@@ -239,7 +239,7 @@ fn mint_with_commit_param_mismatch_should_not_work() {
 		let payload = generate_mint_payload_helper(50);
 		assert_ok!(Assets::mint_private_asset(Origin::signed(1), payload));
 
-		CommitParamChecksum::put([3u8;32]);
+		CommitParamChecksum::put([3u8; 32]);
 
 		assert_noop!(
 			Assets::mint_private_asset(Origin::signed(1), payload),

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -191,10 +191,10 @@ fn mint_with_existing_coin_should_not_work() {
 }
 
 #[test]
-fn mint_with_invalid_commit_should_not_work() {
+fn mint_with_invalid_commitment_should_not_work() {
 	new_test_ext().execute_with(|| {
 		mint_tokens_setup_helper();
-
+		
 		let commit_param = CommitmentParam::deserialize(
 			Parameter {
 				data: &[0u8; 81664],
@@ -206,6 +206,40 @@ fn mint_with_invalid_commit_should_not_work() {
 		rng.fill_bytes(&mut sk);
 		let asset = MantaAsset::sample(&commit_param, &sk, &TEST_ASSET, &50, &mut rng);
 		let payload = generate_mint_payload(&asset);
+
+		assert_noop!(
+			Assets::mint_private_asset(Origin::signed(1), payload),
+			Error::<Test>::MintFail
+		);
+	});
+}
+
+#[test]
+fn mint_with_hash_param_mismatch_should_not_work() {
+	new_test_ext().execute_with(|| {
+		mint_tokens_setup_helper();
+
+		let payload = generate_mint_payload_helper(50);
+		assert_ok!(Assets::mint_private_asset(Origin::signed(1), payload));
+
+		HashParamChecksum::put([3u8;32]);
+
+		assert_noop!(
+			Assets::mint_private_asset(Origin::signed(1), payload),
+			Error::<Test>::MintFail
+		);
+	});
+}
+
+#[test]
+fn mint_with_commit_param_mismatch_should_not_work() {
+	new_test_ext().execute_with(|| {
+		mint_tokens_setup_helper();
+
+		let payload = generate_mint_payload_helper(50);
+		assert_ok!(Assets::mint_private_asset(Origin::signed(1), payload));
+
+		CommitParamChecksum::put([3u8;32]);
 
 		assert_noop!(
 			Assets::mint_private_asset(Origin::signed(1), payload),

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -345,6 +345,16 @@ fn transferring_more_units_than_total_supply_should_not_work() {
 }
 
 #[test]
+fn transferring_without_init_should_not_work() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Assets::transfer_asset(Origin::signed(1), 2, TEST_ASSET, 101),
+			Error::<Test>::BasecoinNotInit
+		);
+	});
+}
+
+#[test]
 fn destroying_asset_balance_with_positive_balance_should_work() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Assets::init_asset(Origin::signed(1), TEST_ASSET, 100));


### PR DESCRIPTION
closes #48 

* Adding the following must-fail tests for the mint_private_asset extrinsic
    - mint_without_init_should_not_work
    - mint_zero_amount_should_not_work
    - mint_with_insufficient_origin_balance_should_not_work
    - mint_with_eisting_coin_should_not_work
    - mint_with_hash_param_mismatch_should_not_work
    - mint_with_commit_param_mismatch_should_not_work
    - mint_with_invalid_commitment_should_not_work

* Adding the following must-fail tests for the transfer_asset extrinsic
    - transferring_without_init_should_not_work
  
* Fixed usage of wrong weight function for the ```init_asset``` extrinsic