### PR TITLE
CI to include manta repo when pallet-manta-pay is updated

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,5 +64,9 @@ jobs:
         run: |
           git clone https://github.com/Manta-Network/Manta.git
           cd Manta/
-          sed -i "s@pallet-manta-pay = {git='https://github.com/Manta-Network/pallet-manta-pay', branch='calamari', default-features = false }@pallet-manta-pay = {path= '../', default-features = false }@g" ./runtimes/manta/runtime/Cargo.toml
+          sed -i "s@pallet-manta-pay = \
+          {git='https://github.com/Manta-Network/pallet-manta-pay',\
+          branch='calamari', default-features = false }@pallet-manta-pay\
+          = {path= '../', default-features = false }@g"\
+          ./runtimes/manta/runtime/Cargo.toml
           cargo build --release --all-features

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,8 +65,8 @@ jobs:
           git clone https://github.com/Manta-Network/Manta.git
           cd Manta/
           sed -i "s@pallet-manta-pay = \
-          {git='https://github.com/Manta-Network/pallet-manta-pay',\
-          branch='calamari', default-features = false }@pallet-manta-pay\
-          = {path= '../', default-features = false }@g"\
+          {git='https://github.com/Manta-Network/pallet-manta-pay', \
+          branch='calamari', default-features = false }@pallet-manta-pay \
+          = {path= '../', default-features = false }@g" \
           ./runtimes/manta/runtime/Cargo.toml
           cargo build --release --all-features

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,20 +46,20 @@ jobs:
           rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup component add clippy
           rustup component add rustfmt
-      # - name: Check Formatting
-      #   run: |
-      #     cargo +nightly fmt --all -- --check
-      # - name: Check Clippy
-      #   run: |
-      #     cargo clippy --release --all
-      # - name: Check Build
-      #   run: |
-      #     cargo check --release
-      #     cargo +nightly check --release --features runtime-benchmarks
-      # - name: Run Tests
-      #   run: |
-      #     cargo run --release --bin param_gen
-      #     cargo test --all-features --release
+      - name: Check Formatting
+        run: |
+          cargo +nightly fmt --all -- --check
+      - name: Check Clippy
+        run: |
+          cargo clippy --release --all
+      - name: Check Build
+        run: |
+          cargo check --release
+          cargo +nightly check --release --features runtime-benchmarks
+      - name: Run Tests
+        run: |
+          cargo run --release --bin param_gen
+          cargo test --all-features --release
       - name: Check Manta Runtime
         run: |
           git clone https://github.com/Manta-Network/Manta.git

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,4 +64,5 @@ jobs:
         run: |
           git clone https://github.com/Manta-Network/Manta.git
           cd Manta/
+          sed -i "s@pallet-manta-pay = {git='https://github.com/Manta-Network/pallet-manta-pay', branch='calamari', default-features = false }@pallet-manta-pay = {path= '../', default-features = false }@g" ./runtimes/manta/runtime/Cargo.toml
           cargo build --release --all-features

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,3 +60,8 @@ jobs:
         run: |
           cargo run --release --bin param_gen
           cargo test --all-features --release
+      - name: Check Manta Runtime
+        run: |
+          git clone https://github.com/Manta-Network/Manta.git
+          cd Manta/
+          cargo build --release --all-features

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,20 +46,20 @@ jobs:
           rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup component add clippy
           rustup component add rustfmt
-      - name: Check Formatting
-        run: |
-          cargo +nightly fmt --all -- --check
-      - name: Check Clippy
-        run: |
-          cargo clippy --release --all
-      - name: Check Build
-        run: |
-          cargo check --release
-          cargo +nightly check --release --features runtime-benchmarks
-      - name: Run Tests
-        run: |
-          cargo run --release --bin param_gen
-          cargo test --all-features --release
+      # - name: Check Formatting
+      #   run: |
+      #     cargo +nightly fmt --all -- --check
+      # - name: Check Clippy
+      #   run: |
+      #     cargo clippy --release --all
+      # - name: Check Build
+      #   run: |
+      #     cargo check --release
+      #     cargo +nightly check --release --features runtime-benchmarks
+      # - name: Run Tests
+      #   run: |
+      #     cargo run --release --bin param_gen
+      #     cargo test --all-features --release
       - name: Check Manta Runtime
         run: |
           git clone https://github.com/Manta-Network/Manta.git

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,6 +67,6 @@ jobs:
           sed -i "s@pallet-manta-pay = \
           {git='https://github.com/Manta-Network/pallet-manta-pay', \
           branch='calamari', default-features = false }@pallet-manta-pay \
-          = {path= '../', default-features = false }@g" \
+          = {path= '../../../../', default-features = false }@g" \
           ./runtimes/manta/runtime/Cargo.toml
           cargo build --release --all-features


### PR DESCRIPTION
closes #54 

Add additional CI to checkout and build the Manta repository when pallet-manta-pay is updated:

1. git clone https://github.com/Manta-Network/Manta
2. cd Manta
3. replace line in Cargo.toml file with ```sed```
4. cargo build --release --all-features