### PR TITLE
[WIP] Add reclaim extrinsic must fail tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
+checksum = "b2333ac5777aaa1beb8589f5374976ae7dc8aa4f09fd21ae3d8662ca97f5247d"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -47,9 +47,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "ahash"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-slice-cast"
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -661,11 +661,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -1186,7 +1185,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.2",
+ "ahash 0.7.4",
 ]
 
 [[package]]
@@ -1349,9 +1348,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "libm"
@@ -1422,7 +1421,7 @@ dependencies = [
 [[package]]
 name = "manta-crypto"
 version = "3.0.0"
-source = "git+https://github.com/Manta-Network/manta-crypto?branch=master#a23182964290aa30cb7e28b1b8958538b6d3c992"
+source = "git+https://github.com/Manta-Network/manta-crypto?branch=master#63e52df4ef1c3f9b8c6db87d8d20287036877105"
 dependencies = [
  "aes",
  "ark-bls12-381",
@@ -1472,9 +1471,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -1848,9 +1847,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2753,18 +2752,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2918,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec051edf7f0fc9499a2cb0947652cab2148b9d7f61cee7605e312e9f970dacaf"
+checksum = "cd81fe0c8bc2b528a51c9d2c31dae4483367a26a723a3c9a4a8120311d7774e3"
 dependencies = [
  "hash-db",
  "hashbrown 0.9.1",
@@ -2975,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "33717dca7ac877f497014e10d73f3acf948c342bee31b5ca7892faf94ccc6b49"
 dependencies = [
  "tinyvec",
 ]

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -472,7 +472,6 @@ fn transferring_spent_coin_should_not_work_sender_2() {
 
 		let (_, receivers_processed) = build_receivers(&commit_param, &mut sk, &mut rng, size);
 
-
 		let payload = prepare_private_transfer_payload(
 			&senders,
 			&commit_param,

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -682,29 +682,26 @@ fn reclaim_with_overdrawn_pool_should_not_work() {
 
 		let (commit_param, hash_param, pk, mut sk, mut rng) = setup_params_for_reclaim();
 
-		let iter = 1;
-		let size = iter << 1;
+		let size = 2;
 		let senders = mint_tokens_helper(size);
 
-		for i in 0usize..iter {
-			let (payload, _, _, _, _) = prepare_reclaim_payload(
-				&senders,
-				&commit_param,
-				&hash_param,
-				&pk,
-				&mut sk,
-				&mut rng,
-				i * 2,
-				i * 2 + 1,
-			);
+		let (payload, _, _, _, _) = prepare_reclaim_payload(
+			&senders,
+			&commit_param,
+			&hash_param,
+			&pk,
+			&mut sk,
+			&mut rng,
+			0,
+			1,
+		);
 
-			assert_ok!(Assets::reclaim(Origin::signed(1), payload));
+		assert_ok!(Assets::reclaim(Origin::signed(1), payload));
 
-			assert_noop!(
-				Assets::reclaim(Origin::signed(1), payload),
-				Error::<Test>::PoolOverdrawn
-			);
-		}
+		assert_noop!(
+			Assets::reclaim(Origin::signed(1), payload),
+			Error::<Test>::PoolOverdrawn
+		);
 	});
 }
 

--- a/src/zkp/verifier.rs
+++ b/src/zkp/verifier.rs
@@ -29,7 +29,7 @@ impl MantaZKPVerifier for PrivateTransferData {
 				return false;
 			}
 		};
-		
+
 		let pvk = Groth16Pvk::from(vk);
 		let proof = match Groth16Proof::deserialize(self.proof.as_ref()) {
 			Ok(p) => p,

--- a/src/zkp/verifier.rs
+++ b/src/zkp/verifier.rs
@@ -29,7 +29,7 @@ impl MantaZKPVerifier for PrivateTransferData {
 				return false;
 			}
 		};
-
+		
 		let pvk = Groth16Pvk::from(vk);
 		let proof = match Groth16Proof::deserialize(self.proof.as_ref()) {
 			Ok(p) => p,
@@ -130,14 +130,49 @@ impl MantaZKPVerifier for ReclaimData {
 	/// This algorithm verifies the ZKP, given the verification key and the data.
 	fn verify(&self, reclaim_key_bytes: &VerificationKey) -> bool {
 		let buf: &[u8] = reclaim_key_bytes.data;
-		let vk = Groth16Vk::deserialize_unchecked(buf).unwrap();
+		let vk = match Groth16Vk::deserialize_unchecked(buf) {
+			Ok(p) => p,
+			Err(_e) => {
+				return false;
+			}
+		};
 		let pvk = Groth16Pvk::from(vk);
-		let proof = Groth16Proof::deserialize(self.proof.as_ref()).unwrap();
-		let k_old_1 = CommitmentOutput::deserialize(self.sender_1.k.as_ref()).unwrap();
-		let k_old_2 = CommitmentOutput::deserialize(self.sender_2.k.as_ref()).unwrap();
-		let cm_new = CommitmentOutput::deserialize(self.receiver.cm.as_ref()).unwrap();
-		let merkle_root_1 = HashOutput::deserialize(self.sender_1.root.as_ref()).unwrap();
-		let merkle_root_2 = HashOutput::deserialize(self.sender_2.root.as_ref()).unwrap();
+		let proof = match Groth16Proof::deserialize(self.proof.as_ref()) {
+			Ok(p) => p,
+			Err(_e) => {
+				return false;
+			}
+		};
+		let k_old_1 = match CommitmentOutput::deserialize(self.sender_1.k.as_ref()) {
+			Ok(p) => p,
+			Err(_e) => {
+				return false;
+			}
+		};
+		let k_old_2 = match CommitmentOutput::deserialize(self.sender_2.k.as_ref()) {
+			Ok(p) => p,
+			Err(_e) => {
+				return false;
+			}
+		};
+		let cm_new = match CommitmentOutput::deserialize(self.receiver.cm.as_ref()) {
+			Ok(p) => p,
+			Err(_e) => {
+				return false;
+			}
+		};
+		let merkle_root_1 = match HashOutput::deserialize(self.sender_1.root.as_ref()) {
+			Ok(p) => p,
+			Err(_e) => {
+				return false;
+			}
+		};
+		let merkle_root_2 = match HashOutput::deserialize(self.sender_2.root.as_ref()) {
+			Ok(p) => p,
+			Err(_e) => {
+				return false;
+			}
+		};
 
 		let mut inputs = [
 			k_old_1.x, k_old_1.y, // sender coin 1
@@ -146,12 +181,32 @@ impl MantaZKPVerifier for ReclaimData {
 		]
 		.to_vec();
 		let sn_1: Vec<Fq> =
-			ToConstraintField::<Fq>::to_field_elements(self.sender_1.void_number.as_ref()).unwrap();
+			match ToConstraintField::<Fq>::to_field_elements(self.sender_1.void_number.as_ref()) {
+				Some(p) => p,
+				None => {
+					return false;
+				}
+			};
 		let sn_2: Vec<Fq> =
-			ToConstraintField::<Fq>::to_field_elements(self.sender_2.void_number.as_ref()).unwrap();
+			match ToConstraintField::<Fq>::to_field_elements(self.sender_2.void_number.as_ref()) {
+				Some(p) => p,
+				None => {
+					return false;
+				}
+			};
 
-		let mr_1: Vec<Fq> = ToConstraintField::<Fq>::to_field_elements(&merkle_root_1).unwrap();
-		let mr_2: Vec<Fq> = ToConstraintField::<Fq>::to_field_elements(&merkle_root_2).unwrap();
+		let mr_1: Vec<Fq> = match ToConstraintField::<Fq>::to_field_elements(&merkle_root_1) {
+			Some(p) => p,
+			None => {
+				return false;
+			}
+		};
+		let mr_2: Vec<Fq> = match ToConstraintField::<Fq>::to_field_elements(&merkle_root_2) {
+			Some(p) => p,
+			None => {
+				return false;
+			}
+		};
 		let value_fq = Fq::from(self.reclaim_amount);
 		let asset_id_fq = Fq::from(self.asset_id as u64);
 		inputs = [
@@ -165,6 +220,9 @@ impl MantaZKPVerifier for ReclaimData {
 		]
 		.concat();
 
-		verify_proof(&pvk, &proof, &inputs[..]).unwrap()
+		match verify_proof(&pvk, &proof, &inputs[..]) {
+			Ok(p) => p,
+			Err(_e) => false,
+		}
 	}
 }


### PR DESCRIPTION


Adding the following must-fail tests for the private_transfer extrinsic
* reclaim_with_hash_param_mismatch_should_not_work
* reclaim_with_overdrawn_pool_should_not_work
* reclaim_spent_coin_should_not_work
* reclaim_spent_coin_should_not_work_2
* reclaim_with_invalid_zkp_param_should_not_work
* reclaim_with_invalid_ledger_state_should_not_work
* reclaim_with_zkp_verification_fail_should_not_work