### PR TITLE
[ready-to-merge] Fix dependency issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 data-encoding = { version = "2.3.2", default-features = false, features = [ "alloc" ] }
 log = { version = "0.4.14", default-features = false }
 
+# Arkworks dependencies
+
+# Attention! This needs to be included before the manta dependencies.
+ark-std = { version = "0.2.0", default-features = false }
+
 # Manta Dependencies
 
 # Attention! Our integration test scripts modify these dependencies with "sed" command.
@@ -46,8 +51,6 @@ serde = { default-features = false, version = '1' }
 sp-core = { default-features = false, version = '3.0.0' }
 sp-io = { default-features = false, version = '3.0.0' }
 
-# Arkworks dependencies
-ark-std = { version = "0.2.0", default-features = false }
 ark-bls12-381 = { version = "0.2.0", default-features = false, features = [ "curve" ] }
 ark-crypto-primitives = { version = "0.2.0", default-features = false, features = [ "r1cs" ] }
 ark-ed-on-bls12-381 = { version = "0.2.0", default-features = false, features = [ "r1cs" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,17 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 data-encoding = { version = "2.3.2", default-features = false, features = [ "alloc" ] }
 log = { version = "0.4.14", default-features = false }
 
-# Arkworks dependencies
-ark-std = { version = "0.2.0", default-features = false }
-
 # Manta Dependencies
+
+# Attention! Our integration test scripts modify these dependencies with "sed" command.
+# If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
+# Search for "Check Pallet-Manta-Pay" in Manta-Network repositories to find the relevant scripts.
 manta-asset = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
 manta-crypto = { branch = "manta", git = "https://github.com/Manta-Network/manta-crypto", default-features = false }
 manta-data = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
 manta-error = { branch = "manta", git = "https://github.com/Manta-Network/manta-error", default-features = false }
 manta-ledger = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
+manta-api = { branch = "manta", git = "https://github.com/Manta-Network/manta-api", default-features = false, features = [ "std" ] }
 
 [dev-dependencies]
 # benchmarking 
@@ -44,6 +46,8 @@ serde = { default-features = false, version = '1' }
 sp-core = { default-features = false, version = '3.0.0' }
 sp-io = { default-features = false, version = '3.0.0' }
 
+# Arkworks dependencies
+ark-std = { version = "0.2.0", default-features = false }
 ark-bls12-381 = { version = "0.2.0", default-features = false, features = [ "curve" ] }
 ark-crypto-primitives = { version = "0.2.0", default-features = false, features = [ "r1cs" ] }
 ark-ed-on-bls12-381 = { version = "0.2.0", default-features = false, features = [ "r1cs" ] }
@@ -53,7 +57,6 @@ ark-relations = { version = "0.2.0", default-features = false }
 ark-serialize = { version = "0.2.0", default-features = false, features = [ "derive" ] }
 
 rand_chacha = { version = "0.2.0", default-features = false }
-manta-api = { branch = "manta", git = "https://github.com/Manta-Network/manta-api", default-features = false, features = [ "std" ] }
 
 [[bench]]
 name = "manta_bench"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,6 @@
 // #![cfg_attr(not(feature = "std"), no_std)]
 #![no_std]
 
-#[cfg(test)]
 #[cfg(feature = "runtime-benchmarks")]
 mod runtime_benchmark;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,7 @@
 // Ensure we're `no_std` when compiling for Wasm.
 // #![cfg_attr(not(feature = "std"), no_std)]
 #![no_std]
-#![cfg(feature = "runtime-benchmarks")]
-
+//#![cfg(feature = "runtime-benchmarks")]
 #[cfg(test)]
 mod runtime_benchmark;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,9 @@
 // Ensure we're `no_std` when compiling for Wasm.
 // #![cfg_attr(not(feature = "std"), no_std)]
 #![no_std]
-//#![cfg(feature = "runtime-benchmarks")]
+
 #[cfg(test)]
+#[cfg(feature = "runtime-benchmarks")]
 mod runtime_benchmark;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,9 +102,9 @@
 // Ensure we're `no_std` when compiling for Wasm.
 // #![cfg_attr(not(feature = "std"), no_std)]
 #![no_std]
+#![cfg(feature = "runtime-benchmarks")]
 
 #[cfg(test)]
-//#![cfg(feature = "runtime-benchmarks")]
 mod runtime_benchmark;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,9 @@
 // Ensure we're `no_std` when compiling for Wasm.
 // #![cfg_attr(not(feature = "std"), no_std)]
 #![no_std]
-#![cfg(feature = "runtime-benchmarks")]
+
+#[cfg(test)]
+//#![cfg(feature = "runtime-benchmarks")]
 mod runtime_benchmark;
 
 #[cfg(test)]


### PR DESCRIPTION
closes #68 
closes Manta-Network/Manta#84

* An ``inner attribute`` - ``#![cfg(feature = "runtime-benchmarks")]`` was introduced in ``lib.rs`` with this commit https://github.com/Manta-Network/pallet-manta-pay/pull/61/commits/ec887c19ff36397a5f0911e69296b6ac72b4fcf5 which disabled all our tests.
* This was also causing errors when integrating manta-pay into the manta runtime node :
   `` error: duplicate lang item in crate `std` (which `pallet_manta_pay` depends on): `panic_impl` ``
* Made it an ``outer attribute`` for the ``mod runtime_benchmark;`` line.