### PR TITLE
[ready-to-merge] Update manta dependencies to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "manta-api"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-api?branch=manta#5ff518dbb2ebf5079d6b0c718510dae605034cbd"
+source = "git+https://github.com/Manta-Network/manta-api?branch=manta#3caf57cda748be54e4d56f4022680ddcc5163362"
 dependencies = [
  "ark-bls12-381",
  "ark-crypto-primitives",
@@ -1439,7 +1439,7 @@ dependencies = [
 [[package]]
 name = "manta-asset"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#3349da1275b78ee75984332d16cc44e3a5e241d1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#69bcc7780bcc41997c1c367a7336fcf6f8bed327"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ed-on-bls12-381",
@@ -1454,7 +1454,7 @@ dependencies = [
 [[package]]
 name = "manta-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-crypto?branch=manta#878f163a8659e032887719a82b02556409716071"
+source = "git+https://github.com/Manta-Network/manta-crypto?branch=manta#ceae75da693fe9bcf62566591c0eed7ece8afeb2"
 dependencies = [
  "aes",
  "ark-bls12-381",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "manta-data"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#3349da1275b78ee75984332d16cc44e3a5e241d1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#69bcc7780bcc41997c1c367a7336fcf6f8bed327"
 dependencies = [
  "ark-ed-on-bls12-381",
  "ark-groth16",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "manta-error"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-error?branch=manta#13fe1ace32ee4b4a3b037640c2d4689bbbdb6759"
+source = "git+https://github.com/Manta-Network/manta-error?branch=manta#17b9a995564bacd4557b98581d7bb1cf02819847"
 dependencies = [
  "ark-crypto-primitives",
  "ark-relations",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "manta-ledger"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#3349da1275b78ee75984332d16cc44e3a5e241d1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#69bcc7780bcc41997c1c367a7336fcf6f8bed327"
 dependencies = [
  "manta-crypto",
  "manta-error",


### PR DESCRIPTION
closes Manta-Network/Manta#84

* `` cargo update -p manta-error `` to bring the dependency to Manta-Network/manta-error@17b9a99
* `` cargo update -p manta-crypto `` to bring the dependency to Manta-Network/manta-crypto@ceae75d
* `` cargo update -p manta-asset,manta-data, manta-ledger `` to bring dependencies to https://github.com/Manta-Network/manta-types/commit/69bcc7780bcc41997c1c367a7336fcf6f8bed327
* ``cargo update -p manta-api`` to bring the dependency to https://github.com/Manta-Network/manta-api/commit/3caf57cda748be54e4d56f4022680ddcc5163362