### PR TITLE
Consistent naming for checksum storage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ decl_module! {
 					<Error<T>>::ParamFail.into()
 				})?;
 
-			TransferZKPKeyChecksum::put(transfer_key_digest);
+			TransferZkpKeyChecksum::put(transfer_key_digest);
 
 			let reclaim_key_digest = RECLAIM_PK.get_checksum()
 				.map_err::<DispatchError, _>(|e| {
@@ -225,7 +225,7 @@ decl_module! {
 					<Error<T>>::ParamFail.into()
 				})?;
 
-			ReclaimZKPKeyChecksum::put(reclaim_key_digest);
+			ReclaimZkpKeyChecksum::put(reclaim_key_digest);
 
 			// deposit the event then update the storage
 			Self::deposit_event(RawEvent::Issued(asset_id, origin.clone(), total));
@@ -485,7 +485,7 @@ decl_module! {
 				})?;
 
 			// get the verification key from the ledger
-			let transfer_vk_checksum = TransferZKPKeyChecksum::get();
+			let transfer_vk_checksum = TransferZkpKeyChecksum::get();
 			let transfer_vk = TRANSFER_PK;
 			let transfer_vk_checksum_local = transfer_vk.get_checksum()
 				.map_err::<DispatchError, _>(|e| {
@@ -587,7 +587,7 @@ decl_module! {
 			let mut coin_shards = CoinShards::get();
 
 			// get the verification key from the ledger
-			let reclaim_vk_checksum = ReclaimZKPKeyChecksum::get();
+			let reclaim_vk_checksum = ReclaimZkpKeyChecksum::get();
 			let reclaim_vk = RECLAIM_PK;
 			let reclaim_vk_checksum_local = reclaim_vk.get_checksum()
 				.map_err::<DispatchError, _>(|e| {
@@ -746,12 +746,12 @@ decl_storage! {
 		/// The verification key for zero-knowledge proof for transfer protocol.
 		/// At the moment we are storing the whole serialized key
 		/// in the blockchain storage.
-		pub TransferZKPKeyChecksum get(fn transfer_zkp_vk_checksum): [u8; 32];
+		pub TransferZkpKeyChecksum get(fn transfer_zkp_key_checksum): [u8; 32];
 
 		/// The verification key for zero-knowledge proof for reclaim protocol.
 		/// At the moment we are storing the whole serialized key
 		/// in the blockchain storage.
-		pub ReclaimZKPKeyChecksum get(fn reclaim_zkp_vk_checksum): [u8; 32];
+		pub ReclaimZkpKeyChecksum get(fn reclaim_zkp_key_checksum): [u8; 32];
 	}
 }
 

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -592,7 +592,7 @@ fn transferring_with_invalid_zkp_param_should_not_work() {
 
 		let transfer_vk = VerificationKey { data: &[0u8; 2312] };
 		let transfer_key_digest = transfer_vk.get_checksum().unwrap();
-		TransferZKPKeyChecksum::put(transfer_key_digest);
+		TransferZkpKeyChecksum::put(transfer_key_digest);
 		assert_noop!(
 			Assets::private_transfer(Origin::signed(1), payload),
 			Error::<Test>::ZkpParamFail
@@ -1231,7 +1231,7 @@ fn setup_params(file_name: &str) -> (CommitmentParam, HashParam, Groth16Pk, [u8;
 	let commit_param = CommitmentParam::deserialize(COMMIT_PARAM.data).unwrap();
 
 	let pk = load_zkp_keys(file_name);
-	let vk_checksum = TransferZKPKeyChecksum::get();
+	let vk_checksum = TransferZkpKeyChecksum::get();
 	assert_eq!(TRANSFER_PK.get_checksum().unwrap(), vk_checksum);
 
 	let rng = ChaCha20Rng::from_seed([3u8; 32]);
@@ -1245,14 +1245,14 @@ fn setup_params(file_name: &str) -> (CommitmentParam, HashParam, Groth16Pk, [u8;
 
 fn setup_params_for_transferring() -> (CommitmentParam, HashParam, Groth16Pk, [u8; 32], ChaCha20Rng)
 {
-	let vk_checksum = TransferZKPKeyChecksum::get();
+	let vk_checksum = TransferZkpKeyChecksum::get();
 	assert_eq!(TRANSFER_PK.get_checksum().unwrap(), vk_checksum);
 
 	setup_params("transfer_pk.bin")
 }
 
 fn setup_params_for_reclaim() -> (CommitmentParam, HashParam, Groth16Pk, [u8; 32], ChaCha20Rng) {
-	let vk_checksum = ReclaimZKPKeyChecksum::get();
+	let vk_checksum = ReclaimZkpKeyChecksum::get();
 	assert_eq!(RECLAIM_PK.get_checksum().unwrap(), vk_checksum);
 
 	setup_params("reclaim_pk.bin")

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -821,7 +821,7 @@ fn reclaim_with_invalid_zkp_param_should_not_work() {
 
 		let reclaim_vk = VerificationKey { data: &[0u8; 2312] };
 		let reclaim_key_digest = reclaim_vk.get_checksum().unwrap();
-		ReclaimZKPKeyChecksum::put(reclaim_key_digest);
+		ReclaimZkpKeyChecksum::put(reclaim_key_digest);
 		assert_noop!(
 			Assets::reclaim(Origin::signed(1), payload),
 			Error::<Test>::ZkpParamFail


### PR DESCRIPTION
I was having trouble with the macros trying to call `transfer_zkp_key_checksum` and `reclaim_zkp_key_checksum` from `manta-subxt`, so I just changed the variable naming schemes to be consistent with CoinShard and it seemed to fix it, unclear why. This PR is paired with an update to Manta.