### PR TITLE
Change Mint/Transfer/Reclaim Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,8 @@ dependencies = [
 
 [[package]]
 name = "manta-api"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-api?branch=manta#6bb78f88f9783ab1474ba033020ada0433799759"
 dependencies = [
  "ark-bls12-381",
  "ark-crypto-primitives",
@@ -1481,6 +1482,7 @@ dependencies = [
 [[package]]
 name = "manta-asset"
 version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#4378d9c461f8002c0d2b1dce5823f11ee9ae9c84"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ed-on-bls12-381",
@@ -1495,7 +1497,8 @@ dependencies = [
 
 [[package]]
 name = "manta-crypto"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-crypto?branch=manta#125d5eec169a23ac8d631dc29b29bc4f5385169f"
 dependencies = [
  "aes-gcm",
  "ark-bls12-381",
@@ -1515,7 +1518,8 @@ dependencies = [
 
 [[package]]
 name = "manta-data"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#4378d9c461f8002c0d2b1dce5823f11ee9ae9c84"
 dependencies = [
  "ark-ed-on-bls12-381",
  "ark-groth16",
@@ -1530,7 +1534,8 @@ dependencies = [
 
 [[package]]
 name = "manta-error"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-error?branch=manta#00810285947f59b1e051fa7d2d0e1d10bbaf9bd8"
 dependencies = [
  "ark-crypto-primitives",
  "ark-relations",
@@ -1542,7 +1547,8 @@ dependencies = [
 
 [[package]]
 name = "manta-ledger"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#4378d9c461f8002c0d2b1dce5823f11ee9ae9c84"
 dependencies = [
  "manta-crypto",
  "manta-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,6 @@ dependencies = [
 [[package]]
 name = "manta-api"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-api?branch=manta#1db0a888fe31e5ff3dd922e04465f676715e4013"
 dependencies = [
  "ark-bls12-381",
  "ark-crypto-primitives",
@@ -1482,7 +1481,6 @@ dependencies = [
 [[package]]
 name = "manta-asset"
 version = "0.1.1"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#0e20d7e46a8179c53930b60c2ac90d7495ce9ba0"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ed-on-bls12-381",
@@ -1498,7 +1496,6 @@ dependencies = [
 [[package]]
 name = "manta-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-crypto?branch=manta#3418f9d6738ddd78828ff27a72ff89eb68926680"
 dependencies = [
  "aes-gcm",
  "ark-bls12-381",
@@ -1519,7 +1516,6 @@ dependencies = [
 [[package]]
 name = "manta-data"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#0e20d7e46a8179c53930b60c2ac90d7495ce9ba0"
 dependencies = [
  "ark-ed-on-bls12-381",
  "ark-groth16",
@@ -1529,24 +1525,24 @@ dependencies = [
  "manta-asset",
  "manta-crypto",
  "manta-error",
+ "parity-scale-codec",
 ]
 
 [[package]]
 name = "manta-error"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-error?branch=manta#201b4e70577fa282474ceee2008e4e24ba790e21"
 dependencies = [
  "ark-crypto-primitives",
  "ark-relations",
  "ark-serialize",
  "ark-std",
  "displaydoc",
+ "parity-scale-codec",
 ]
 
 [[package]]
 name = "manta-ledger"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#0e20d7e46a8179c53930b60c2ac90d7495ce9ba0"
 dependencies = [
  "manta-crypto",
  "manta-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,12 @@ ark-std = { version = "0.2.0", default-features = false }
 # Attention! Our integration test scripts modify these dependencies with "sed" command.
 # If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
 # Search for "Check Pallet-Manta-Pay" in Manta-Network repositories to find the relevant scripts.
-manta-asset = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
-manta-crypto = { branch = "manta", git = "https://github.com/Manta-Network/manta-crypto", default-features = false }
-manta-data = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
-manta-error = { branch = "manta", git = "https://github.com/Manta-Network/manta-error", default-features = false }
-manta-ledger = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
-manta-api = { branch = "manta", git = "https://github.com/Manta-Network/manta-api", default-features = false, features = [ "std" ] }
+manta-asset = { path = "../manta-types/manta-asset", default-features = false }
+manta-crypto = { path = "../manta-crypto", default-features = false }
+manta-data = { path = "../manta-types/manta-data", default-features = false }
+manta-error = { path = "../manta-error", default-features = false }
+manta-ledger = { path = "../manta-types/manta-ledger", default-features = false }
+manta-api = { path = "../manta-api", default-features = false, features = [ "std" ] }
 
 [dev-dependencies]
 # benchmarking 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,12 @@ ark-std = { version = "0.2.0", default-features = false }
 # Attention! Our integration test scripts modify these dependencies with "sed" command.
 # If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
 # Search for "Check Pallet-Manta-Pay" in Manta-Network repositories to find the relevant scripts.
-manta-asset = { path = "../manta-types/manta-asset", default-features = false }
-manta-crypto = { path = "../manta-crypto", default-features = false }
-manta-data = { path = "../manta-types/manta-data", default-features = false }
-manta-error = { path = "../manta-error", default-features = false }
-manta-ledger = { path = "../manta-types/manta-ledger", default-features = false }
-manta-api = { path = "../manta-api", default-features = false, features = [ "std" ] }
+manta-asset = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
+manta-crypto = { branch = "manta", git = "https://github.com/Manta-Network/manta-crypto", default-features = false }
+manta-data = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
+manta-error = { branch = "manta", git = "https://github.com/Manta-Network/manta-error", default-features = false }
+manta-ledger = { branch = "manta", git = "https://github.com/Manta-Network/manta-types", default-features = false }
+manta-api = { branch = "manta", git = "https://github.com/Manta-Network/manta-api", default-features = false, features = [ "std" ] }
 
 [dev-dependencies]
 # benchmarking 

--- a/src/test/crypto.rs
+++ b/src/test/crypto.rs
@@ -30,8 +30,10 @@ use rand_chacha::ChaCha20Rng;
 /// this is a local test on zero knowledge proof generation and verifications
 #[test]
 fn test_transfer_zkp_local() {
-	let hash_param = HashParam::deserialize(HASH_PARAM.data).unwrap();
-	let commit_param = CommitmentParam::deserialize(COMMIT_PARAM.data).unwrap();
+	let mut hash_param_bytes = HASH_PARAM.data;
+	let mut commit_param_bytes = COMMIT_PARAM.data;
+	let hash_param = HashParam::deserialize(&mut hash_param_bytes).unwrap();
+	let commit_param = CommitmentParam::deserialize(&mut commit_param_bytes).unwrap();
 
 	let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
 
@@ -322,8 +324,10 @@ fn test_transfer_helper(
 /// this is a local test on zero knowledge proof generation and verifications
 #[test]
 fn test_reclaim_zkp_local() {
-	let hash_param = HashParam::deserialize(HASH_PARAM.data).unwrap();
-	let commit_param = CommitmentParam::deserialize(COMMIT_PARAM.data).unwrap();
+	let mut hash_param_bytes = HASH_PARAM.data;
+	let mut commit_param_bytes = COMMIT_PARAM.data;
+	let hash_param = HashParam::deserialize(&mut hash_param_bytes).unwrap();
+	let commit_param = CommitmentParam::deserialize(&mut commit_param_bytes).unwrap();
 
 	let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
 

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -913,9 +913,12 @@ fn mint_tokens_helper(size: usize) -> Vec<MantaAsset> {
 		let payload = generate_mint_struct(&asset);
 
 		//output precomputed coin
-		//println!("mint coin number: {:?}", i);
-		//println!("coin value: {:?}", token_value);
-		//println!("mint payload: {:?}", payload);
+		// println!("mint coin number: {:?}", i);
+		// println!("coin value: {:?}", token_value);
+		// let mut mint_bytes: Vec<u8> = Vec::new();
+		// payload.serialize(&mut mint_bytes).unwrap();
+		// println!("mint payload size: {:?}", mint_bytes.len());
+		// println!("mint payload: {:?}", mint_bytes);
 
 		// mint a sender token
 		assert_ok!(Assets::mint_private_asset(Origin::signed(1), payload));
@@ -968,7 +971,10 @@ fn transfer_test_helper(iter: usize) {
 			i * 2 + 1,
 		);
 
-		//println!("transfer payload {:?}: {:?} ", i, payload);
+		// let mut transfer_bytes: Vec<u8> = Vec::new();
+		// payload.serialize(&mut transfer_bytes).unwrap();
+		// println!("transfer payload size: {:?}", transfer_bytes.len());
+		// println!("transfer payload {:?}: {:?} ", i, transfer_bytes);
 
 		// invoke the transfer event
 		assert_ok!(Assets::private_transfer(Origin::signed(1), payload));
@@ -1041,8 +1047,11 @@ fn reclaim_test_helper(iter: usize) {
 			i * 2 + 1,
 		);
 
-		//println!("reclaim value: {:?}", reclaim_value);
-		//println!("recalim payload: {:?}", payload);
+		// let mut reclaim_bytes: Vec<u8> = Vec::new();
+		// payload.serialize(&mut reclaim_bytes).unwrap();
+		// println!("reclaim value: {:?}", reclaim_value);
+		// println!("reclaim payload size: {:?}", reclaim_bytes.len());
+		// println!("recalim payload: {:?}", reclaim_bytes);
 
 		// invoke the reclaim event
 		assert_ok!(Assets::reclaim(Origin::signed(1), payload));

--- a/src/test/frame.rs
+++ b/src/test/frame.rs
@@ -20,8 +20,7 @@ use ark_serialize::CanonicalDeserialize;
 use ark_std::rand::{RngCore, SeedableRng};
 use frame_support::{assert_noop, assert_ok, parameter_types};
 use manta_api::{
-	generate_mint_payload, generate_private_transfer_payload, generate_reclaim_payload,
-	write_zkp_keys,
+	generate_mint_struct, generate_private_transfer_struct, generate_reclaim_struct, write_zkp_keys,
 };
 use manta_asset::*;
 use manta_crypto::*;
@@ -99,8 +98,10 @@ fn new_test_ext() -> sp_io::TestExternalities {
 fn test_constants_should_work() {
 	new_test_ext().execute_with(|| {
 		initialize_test(100);
-		let hash_param = HashParam::deserialize(HASH_PARAM.data).unwrap();
-		let commit_param = CommitmentParam::deserialize(COMMIT_PARAM.data).unwrap();
+		let mut hash_param_bytes = HASH_PARAM.data;
+		let mut commit_param_bytes = COMMIT_PARAM.data;
+		let hash_param = HashParam::deserialize(&mut hash_param_bytes).unwrap();
+		let commit_param = CommitmentParam::deserialize(&mut commit_param_bytes).unwrap();
 		let hash_param_checksum_local = hash_param.get_checksum().unwrap();
 		let commit_param_checksum_local = commit_param.get_checksum().unwrap();
 		let hash_param_checksum = HashParamChecksum::get();
@@ -157,17 +158,15 @@ fn test_mint_should_work() {
 	new_test_ext().execute_with(|| {
 		initialize_test(1000);
 
-		let commit_param = CommitmentParam::deserialize(COMMIT_PARAM.data).unwrap();
+		let mut commit_param_bytes = COMMIT_PARAM.data;
+		let commit_param = CommitmentParam::deserialize(&mut commit_param_bytes).unwrap();
 		let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
 		let mut sk = [0u8; 32];
 		rng.fill_bytes(&mut sk);
 		let asset = MantaAsset::sample(&commit_param, &sk, &TEST_ASSET, &10).unwrap();
 
-		let payload = generate_mint_payload(&asset);
-		assert_ok!(Assets::mint_private_asset(
-			Origin::signed(1),
-			payload.unwrap()
-		));
+		let payload = generate_mint_struct(&asset);
+		assert_ok!(Assets::mint_private_asset(Origin::signed(1), payload));
 
 		assert_eq!(TotalSupply::get(TEST_ASSET), 1000);
 		assert_eq!(PoolBalance::get(TEST_ASSET), 10);
@@ -239,18 +238,14 @@ fn mint_with_invalid_commitment_should_not_work() {
 	new_test_ext().execute_with(|| {
 		initialize_test(100);
 
-		let commit_param = CommitmentParam::deserialize(
-			Parameter {
-				data: &[0u8; 81664],
-			}
-			.data,
-		)
-		.unwrap();
+		let data: &[u8; 81664] = &[5u8; 81664];
+		let mut raw_param = Parameter { data };
+		let commit_param = CommitmentParam::deserialize(&mut raw_param.data).unwrap();
 		let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
 		let mut sk = [0u8; 32];
 		rng.fill_bytes(&mut sk);
 		let asset = MantaAsset::sample(&commit_param, &sk, &TEST_ASSET, &50).unwrap();
-		let payload = generate_mint_payload(&asset).unwrap();
+		let payload = generate_mint_struct(&asset);
 
 		assert_noop!(
 			Assets::mint_private_asset(Origin::signed(1), payload),
@@ -357,12 +352,12 @@ fn transferring_with_hash_param_mismatch_should_not_work() {
 	new_test_ext().execute_with(|| {
 		initialize_test(10_000_000);
 
-		let payload = [0u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
+		let priv_trans_data = PrivateTransferData::default();
 		HashParamChecksum::put([3u8; 32]);
 
 		// invoke the transfer event
 		assert_noop!(
-			Assets::private_transfer(Origin::signed(1), payload),
+			Assets::private_transfer(Origin::signed(1), priv_trans_data),
 			Error::<Test>::ParamFail
 		);
 	});
@@ -402,7 +397,7 @@ fn transferring_spent_coin_should_not_work_sender_1() {
 				i * 2 + 1,
 			);
 
-			assert_ok!(Assets::private_transfer(Origin::signed(1), payload));
+			assert_ok!(Assets::private_transfer(Origin::signed(1), payload.clone()));
 
 			assert_noop!(
 				Assets::private_transfer(Origin::signed(1), payload),
@@ -523,7 +518,7 @@ fn transferring_with_invalid_ledger_state_should_not_work() {
 
 		let (_, receivers_processed) = build_receivers(&commit_param, &mut sk, &mut rng, size);
 
-		let payload = prepare_private_transfer_payload(
+		let mut data = prepare_private_transfer_payload(
 			&senders,
 			&commit_param,
 			&hash_param,
@@ -534,17 +529,14 @@ fn transferring_with_invalid_ledger_state_should_not_work() {
 			1,
 		);
 
-		let mut data = PrivateTransferData::deserialize(payload.as_ref()).unwrap();
 		data.sender_1.root = [5u8; 32];
-		let mut payload_with_bad_root = [0u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
-		data.serialize(payload_with_bad_root.as_mut()).unwrap();
 
 		assert_noop!(
-			Assets::private_transfer(Origin::signed(1), payload_with_bad_root),
+			Assets::private_transfer(Origin::signed(1), data),
 			Error::<Test>::InvalidLedgerState
 		);
 
-		let payload = prepare_private_transfer_payload(
+		data = prepare_private_transfer_payload(
 			&senders,
 			&commit_param,
 			&hash_param,
@@ -555,13 +547,10 @@ fn transferring_with_invalid_ledger_state_should_not_work() {
 			3,
 		);
 
-		let mut data = PrivateTransferData::deserialize(payload.as_ref()).unwrap();
 		data.sender_2.root = [5u8; 32];
-		let mut payload_with_bad_root = [0u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
-		data.serialize(payload_with_bad_root.as_mut()).unwrap();
 
 		assert_noop!(
-			Assets::private_transfer(Origin::signed(1), payload_with_bad_root),
+			Assets::private_transfer(Origin::signed(1), data),
 			Error::<Test>::InvalidLedgerState
 		);
 	});
@@ -612,7 +601,7 @@ fn transferring_with_zkp_verification_fail_should_not_work() {
 
 		let (_, receivers_processed) = build_receivers(&commit_param, &mut sk, &mut rng, size);
 
-		let payload = prepare_private_transfer_payload(
+		let mut data = prepare_private_transfer_payload(
 			&senders,
 			&commit_param,
 			&hash_param,
@@ -623,13 +612,10 @@ fn transferring_with_zkp_verification_fail_should_not_work() {
 			1,
 		);
 
-		let mut data = PrivateTransferData::deserialize(payload.as_ref()).unwrap();
 		data.proof = [0u8; 192];
-		let mut payload_with_bad_proof = [0u8; PRIVATE_TRANSFER_PAYLOAD_SIZE];
-		data.serialize(payload_with_bad_proof.as_mut()).unwrap();
 
 		assert_noop!(
-			Assets::private_transfer(Origin::signed(1), payload_with_bad_proof),
+			Assets::private_transfer(Origin::signed(1), data),
 			Error::<Test>::ZkpVerificationFail
 		);
 	});
@@ -651,10 +637,10 @@ fn test_reclaim_should_work_super_long() {
 #[test]
 fn reclaim_without_init_should_not_work() {
 	new_test_ext().execute_with(|| {
-		let payload = [0u8; RECLAIM_PAYLOAD_SIZE];
+		let data = ReclaimData::default();
 
 		assert_noop!(
-			Assets::reclaim(Origin::signed(1), payload),
+			Assets::reclaim(Origin::signed(1), data),
 			Error::<Test>::BasecoinNotInit
 		);
 	});
@@ -665,12 +651,12 @@ fn reclaim_with_hash_param_mismatch_should_not_work() {
 	new_test_ext().execute_with(|| {
 		initialize_test(10_000_000);
 
-		let payload = [0u8; RECLAIM_PAYLOAD_SIZE];
+		let data = ReclaimData::default();
 		HashParamChecksum::put([3u8; 32]);
 
 		// invoke the transfer event
 		assert_noop!(
-			Assets::reclaim(Origin::signed(1), payload),
+			Assets::reclaim(Origin::signed(1), data),
 			Error::<Test>::ParamFail
 		);
 	});
@@ -697,7 +683,7 @@ fn reclaim_with_overdrawn_pool_should_not_work() {
 			1,
 		);
 
-		assert_ok!(Assets::reclaim(Origin::signed(1), payload));
+		assert_ok!(Assets::reclaim(Origin::signed(1), payload.clone()));
 
 		assert_noop!(
 			Assets::reclaim(Origin::signed(1), payload),
@@ -839,7 +825,7 @@ fn reclaim_with_invalid_ledger_state_should_not_work() {
 		let size = 4;
 		let senders = mint_tokens_helper(size);
 
-		let (payload, _, _, _, _) = prepare_reclaim_payload(
+		let (mut data, _, _, _, _) = prepare_reclaim_payload(
 			&senders,
 			&commit_param,
 			&hash_param,
@@ -850,17 +836,14 @@ fn reclaim_with_invalid_ledger_state_should_not_work() {
 			1,
 		);
 
-		let mut data = ReclaimData::deserialize(payload.as_ref()).unwrap();
 		data.sender_1.root = [5u8; 32];
-		let mut payload_with_bad_root = [0u8; RECLAIM_PAYLOAD_SIZE];
-		data.serialize(payload_with_bad_root.as_mut()).unwrap();
 
 		assert_noop!(
-			Assets::reclaim(Origin::signed(1), payload_with_bad_root),
+			Assets::reclaim(Origin::signed(1), data),
 			Error::<Test>::InvalidLedgerState
 		);
 
-		let (payload, _, _, _, _) = prepare_reclaim_payload(
+		let (mut data, _, _, _, _) = prepare_reclaim_payload(
 			&senders,
 			&commit_param,
 			&hash_param,
@@ -871,13 +854,10 @@ fn reclaim_with_invalid_ledger_state_should_not_work() {
 			3,
 		);
 
-		let mut data = ReclaimData::deserialize(payload.as_ref()).unwrap();
 		data.sender_2.root = [5u8; 32];
-		let mut payload_with_bad_root = [0u8; RECLAIM_PAYLOAD_SIZE];
-		data.serialize(payload_with_bad_root.as_mut()).unwrap();
 
 		assert_noop!(
-			Assets::reclaim(Origin::signed(1), payload_with_bad_root),
+			Assets::reclaim(Origin::signed(1), data),
 			Error::<Test>::InvalidLedgerState
 		);
 	});
@@ -893,7 +873,7 @@ fn reclaim_with_zkp_verification_fail_should_not_work() {
 		let size = 2;
 		let senders = mint_tokens_helper(size);
 
-		let (payload, _, _, _, _) = prepare_reclaim_payload(
+		let (mut data, _, _, _, _) = prepare_reclaim_payload(
 			&senders,
 			&commit_param,
 			&hash_param,
@@ -904,13 +884,10 @@ fn reclaim_with_zkp_verification_fail_should_not_work() {
 			1,
 		);
 
-		let mut data = ReclaimData::deserialize(payload.as_ref()).unwrap();
 		data.proof = [6u8; 192];
-		let mut payload_with_bad_proof = [0u8; RECLAIM_PAYLOAD_SIZE];
-		data.serialize(payload_with_bad_proof.as_mut()).unwrap();
 
 		assert_noop!(
-			Assets::reclaim(Origin::signed(1), payload_with_bad_proof),
+			Assets::reclaim(Origin::signed(1), data),
 			Error::<Test>::ZkpVerificationFail
 		);
 	});
@@ -919,7 +896,8 @@ fn reclaim_with_zkp_verification_fail_should_not_work() {
 // Helper functions:
 
 fn mint_tokens_helper(size: usize) -> Vec<MantaAsset> {
-	let commit_param = CommitmentParam::deserialize(COMMIT_PARAM.data).unwrap();
+	let mut commit_param_bytes = COMMIT_PARAM.data;
+	let commit_param = CommitmentParam::deserialize(&mut commit_param_bytes).unwrap();
 
 	let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
 	let mut pool = 0;
@@ -932,7 +910,7 @@ fn mint_tokens_helper(size: usize) -> Vec<MantaAsset> {
 		let token_value = 10 + i as AssetBalance;
 		rng.fill_bytes(&mut sk);
 		let asset = MantaAsset::sample(&commit_param, &sk, &TEST_ASSET, &token_value).unwrap();
-		let payload = generate_mint_payload(&asset).unwrap();
+		let payload = generate_mint_struct(&asset);
 
 		//output precomputed coin
 		//println!("mint coin number: {:?}", i);
@@ -953,13 +931,14 @@ fn mint_tokens_helper(size: usize) -> Vec<MantaAsset> {
 	senders
 }
 
-fn generate_mint_payload_helper(value: AssetBalance) -> [u8; MINT_PAYLOAD_SIZE] {
-	let commit_param = CommitmentParam::deserialize(COMMIT_PARAM.data).unwrap();
+fn generate_mint_payload_helper(value: AssetBalance) -> MintData {
+	let mut commit_param_bytes = COMMIT_PARAM.data;
+	let commit_param = CommitmentParam::deserialize(&mut commit_param_bytes).unwrap();
 	let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
 	let mut sk = [0u8; 32];
 	rng.fill_bytes(&mut sk);
 	let asset = MantaAsset::sample(&commit_param, &sk, &TEST_ASSET, &value).unwrap();
-	generate_mint_payload(&asset).unwrap()
+	generate_mint_struct(&asset)
 }
 
 fn transfer_test_helper(iter: usize) {
@@ -1091,7 +1070,7 @@ fn prepare_private_transfer_payload(
 	rng: &mut ChaCha20Rng,
 	sender_1_idx: usize,
 	sender_2_idx: usize,
-) -> [u8; PRIVATE_TRANSFER_PAYLOAD_SIZE] {
+) -> PrivateTransferData {
 	// build sender mata data
 	let (sender_1, sender_2) =
 		build_sender_meta_data(&senders, &hash_param, sender_1_idx, sender_2_idx);
@@ -1101,7 +1080,7 @@ fn prepare_private_transfer_payload(
 	let receiver_2 = receivers_processed[sender_1_idx].clone();
 
 	// form the transaction payload
-	generate_private_transfer_payload(
+	generate_private_transfer_struct(
 		commit_param.clone(),
 		hash_param.clone(),
 		&pk,
@@ -1124,7 +1103,7 @@ fn prepare_reclaim_payload(
 	sender_1_idx: usize,
 	sender_2_idx: usize,
 ) -> (
-	[u8; RECLAIM_PAYLOAD_SIZE],
+	ReclaimData,
 	SenderMetaData,
 	SenderMetaData,
 	AssetBalance,
@@ -1142,7 +1121,7 @@ fn prepare_reclaim_payload(
 		sender_1.asset.priv_info.value + sender_2.asset.priv_info.value - receiver.value;
 
 	// form the transaction payload
-	let payload = generate_reclaim_payload(
+	let payload = generate_reclaim_struct(
 		commit_param.clone(),
 		hash_param.clone(),
 		&pk,
@@ -1227,8 +1206,10 @@ fn build_receivers(
 }
 
 fn setup_params(file_name: &str) -> (CommitmentParam, HashParam, Groth16Pk, [u8; 32], ChaCha20Rng) {
-	let hash_param = HashParam::deserialize(HASH_PARAM.data).unwrap();
-	let commit_param = CommitmentParam::deserialize(COMMIT_PARAM.data).unwrap();
+	let mut hash_param_bytes = HASH_PARAM.data;
+	let mut commit_param_bytes = COMMIT_PARAM.data;
+	let hash_param = HashParam::deserialize(&mut hash_param_bytes).unwrap();
+	let commit_param = CommitmentParam::deserialize(&mut commit_param_bytes).unwrap();
 
 	let pk = load_zkp_keys(file_name);
 	let vk_checksum = TransferZkpKeyChecksum::get();


### PR DESCRIPTION
As we refactor serdes, since we use the standard parity scale codec now, we can use the `MintData`, `PrivateTransferData` and `ReclaimData` directly as arguments. This potentially simplifies many things, including the front-end code.